### PR TITLE
Kill options config prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,7 @@ To use with your Models add the `mixins` attribute to the definition object of y
     },
     "mixins": {
         "Paginate": {
-            "config": {
-                "limit": "10"
-            }
+            "limit": "10"
         }
     }
 }

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function Paginate(Model, options) {
 
     // Check if limit is passed otherwise set to mixin config or default
     if (_.isUndefined(query.limit)) {
-      query.limit = options.config.limit || 10;
+      query.limit = options.limit || 10;
       debug(debugPrefix + 'paginate: limit undefined, using default:', query.limit);
     } else {
       debug(debugPrefix + 'paginate: limit defined: %s', query.limit);


### PR DESCRIPTION
Here PR!
Test are not passing because config prop doesnt exists, now with this fix works ok.

```
 1) Paginate without parameters

  3 passing (108ms)
  1 failing

  1) loopback datasource paginate mixin Testing behaviour Model.paginate Paginate without parameters:
     TypeError: Cannot read property 'limit' of undefined
      at Function.Paginate.Model.paginate (index.js:27:35)                                                                                                              
      at Context.<anonymous> (test.js:80:19)    
```
